### PR TITLE
Engops 3984 pin jnlp/aws docker image to a most recent commit sha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/inbound-agent:6af88634438c82339b4eb55b13b5e141eabedc8c
+FROM jenkins/inbound-agent:3131.vf2b_b_798b_ce99-3-jdk11
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM jenkins/inbound-agent
 
+FROM vestmarkorg/jnlp-aws:6af88634438c82339b4eb55b13b5e141eabedc8c
+
 USER root
 
 RUN apt-get update && apt-get install -y sudo curl zip unzip less groff python3 python3-pip python-is-python3 build-essential zlib1g-dev libssl-dev libncurses-dev libffi-dev libsqlite3-dev libreadline-dev libbz2-dev amazon-ecr-credential-helper jq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM jenkins/inbound-agent
-
-FROM vestmarkorg/jnlp-aws:6af88634438c82339b4eb55b13b5e141eabedc8c
+FROM jenkins/inbound-agent:6af88634438c82339b4eb55b13b5e141eabedc8c
 
 USER root
 


### PR DESCRIPTION
The static analysis tools deployed on the container image gets updated to their latest versions, whenever this docker image is rebuilt. So pinning this docker image to a most recent commit SHA from latest tag.